### PR TITLE
Fix pcap_info (#2 and #3)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 [24.10.1]
-* Big fix (check_output decode)
+* Big fix (check_output decode, pytz dependency)
 
 [1.3]
  * Reference file in PCAP manager in report field

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 CHANGELOG
 =========
+[24.10.1]
+* Big fix (check_output decode)
 
 [1.3]
  * Reference file in PCAP manager in report field

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ http://pythonhosted.org/steelscript/
         'steelscript>=24.2.0',
         'python-dateutil',
         'tzlocal',
+        'pytz'
     ),
 
     'extras_require': None,

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools import setup, find_packages
 
 setup_args = {
     'name':                'steelscript.wireshark',
-    'version':             '24.2.1',
+    'version':             '24.10.1',
     'author':              'Riverbed Technology',
     'author_email':        'eng-github@riverbed.com',
     'url':                 'http://pythonhosted.org/steelscript',
@@ -57,7 +57,7 @@ http://pythonhosted.org/steelscript/
         ('share/doc/steelscript/examples/wireshark', glob('examples/*')),
     ),
 
-    'python_requires': '>3.5.0',
+    'python_requires': '>3.9.0',
 
     'classifiers': [
         'Framework :: Django',

--- a/steelscript/wireshark/core/pcap.py
+++ b/steelscript/wireshark/core/pcap.py
@@ -210,7 +210,7 @@ class PcapFile(object):
 
         # Use steelscript-packets if available and requested
         if PcapFile.HAVE_STEELSCRIPT_PACKETS and use_ss_packets:
-            pq = PcapQuery()
+            pq = PcapQuery(filename=self.filename)
             if pq.fields_supported(fieldnames and
                     filterexpr in [None, ''] and duration is None and
                     occurrence == self.OCCURRENCE_ALL and

--- a/steelscript/wireshark/core/pcap.py
+++ b/steelscript/wireshark/core/pcap.py
@@ -91,7 +91,6 @@ class PcapFile(object):
                 capinfos = subprocess.check_output(cmd,
                                                    env=popen_env,
                                                    universal_newlines=True)
-                capinfos = capinfos.decode('utf8')
                 hdrs, vals = (capinfos.split('\n')[:2])
                 self._info = dict(zip(hdrs.split(','), vals.split(',')))
 

--- a/steelscript/wireshark/core/pcap.py
+++ b/steelscript/wireshark/core/pcap.py
@@ -210,11 +210,8 @@ class PcapFile(object):
 
         # Use steelscript-packets if available and requested
         if PcapFile.HAVE_STEELSCRIPT_PACKETS and use_ss_packets:
-            pq = PcapQuery(filename=self.filename)
-            if pq.fields_supported(fieldnames and
-                    filterexpr in [None, ''] and duration is None and
-                    occurrence == self.OCCURRENCE_ALL and
-                    aggregator == ','):
+            pq = PcapQuery(filename=self.filename,wshark_fields=fieldnames)
+            if pq.fields_supported(fieldnames) and filterexpr in [None, ''] and duration is None and occurrence == self.OCCURRENCE_ALL and aggregator == ',':
                 stime = 0.0
                 etime = 0.0
                 rdf = 1 if as_dataframe else 0
@@ -225,10 +222,8 @@ class PcapFile(object):
                     if isinstance(endtime, str):
                         etime = dateutil_parse(endtime)
 
-                logger.debug(
-                    "PcapFile.query() run using PcapQuery.pcap_query().")
-                with open(self.filename, 'rb') as f:
-                    return pq.pcap_query(f, fieldnames, stime, etime, rdf=rdf)
+                logger.debug("PcapFile.query() run using PcapQuery.pcap_query().")
+                return pq.query(starttime=stime, endtime=etime, num_packets=0, dataframe=rdf)
 
         # Continue with native tshark query instead
         cmd = ['tshark', '-r', self.filename,

--- a/steelscript/wireshark/core/pcap.py
+++ b/steelscript/wireshark/core/pcap.py
@@ -92,7 +92,6 @@ class PcapFile(object):
                 capinfos = subprocess.check_output(cmd,
                                                    env=popen_env,
                                                    universal_newlines=True)
-                capinfos = capinfos.decode('utf8')
                 hdrs, vals = (capinfos.split('\n')[:2])
                 self._info = dict(zip(hdrs.split(','), vals.split(',')))
 

--- a/steelscript/wireshark/core/pcap.py
+++ b/steelscript/wireshark/core/pcap.py
@@ -65,8 +65,12 @@ class PcapFile(object):
             if PcapFile.HAVE_STEELSCRIPT_PACKETS:
                 logger.debug(
                     "PcapFile.info() run using steelscript pcap library.")
-                with open(self.filename, 'rb') as pfile:
-                    pfile_info = pcap_info(pfile)
+                # TODO: validate pcap_info is expecting a filename (v2) and not pfile which is a BufferedReader (v1)
+                # v1
+                # with open(self.filename, 'rb') as pfile:
+                #     pfile_info = pcap_info(pfile)
+                # v2
+                pcap_info(self.filename)
 
                 self._info = {'Start time': pfile_info['first_timestamp'],
                               'End time': pfile_info['last_timestamp'],

--- a/steelscript/wireshark/core/pcap.py
+++ b/steelscript/wireshark/core/pcap.py
@@ -63,14 +63,10 @@ class PcapFile(object):
         steelscript's pcap library internally depending on environment."""
         if self._info is None:
             if PcapFile.HAVE_STEELSCRIPT_PACKETS:
-                logger.debug(
-                    "PcapFile.info() run using steelscript pcap library.")
-                # TODO: validate pcap_info is expecting a filename (v2) and not pfile which is a BufferedReader (v1)
-                # v1
-                # with open(self.filename, 'rb') as pfile:
-                #     pfile_info = pcap_info(pfile)
-                # v2
-                pcap_info(self.filename)
+                logger.debug("PcapFile.info() run using steelscript pcap library.")
+                
+                # pcap_info is expecting a filename
+                pfile_info = pcap_info(self.filename)
 
                 self._info = {'Start time': pfile_info['first_timestamp'],
                               'End time': pfile_info['last_timestamp'],


### PR DESCRIPTION
Fixing #3 #2
* Fix output decode issue (capinfos.decode)
* Fix ModuleNotFoundError: No module named 'pytz' 
* Change the dynamic import and detection of the steelscript-packets module (HAVE_STEELSCRIPT_PACKETS)
* Use new PcapQuery (see https://github.com/riverbed/steelscript-wireshark , PR version 24.10.1)